### PR TITLE
Fixing time display for non-GMT site defined timezones

### DIFF
--- a/includes/class-revisr-admin.php
+++ b/includes/class-revisr-admin.php
@@ -106,7 +106,7 @@ class Revisr_Admin {
 	 */
 	public static function log( $message, $event ) {
 		global $wpdb;
-		$time  = current_time( 'mysql', 1 );
+		$time  = current_time( 'mysql' );
 		$table = $wpdb->prefix . 'revisr';
 		$wpdb->insert(
 			"$table",


### PR DESCRIPTION
Found that some of our sites are displaying event times in the Dashboard that are not in sync with the WP-defined time or the server time. For sanity's sake, we would like to see these in GMT-8!
