### PR TITLE
Translations loading fix

### DIFF
--- a/includes/class-revisr-i18n.php
+++ b/includes/class-revisr-i18n.php
@@ -33,7 +33,7 @@ class Revisr_i18n {
 		load_plugin_textdomain(
 			$this->domain,
 			false,
-			REVISR_PATH . 'languages/'
+			$this->domain . '/languages/'
 		);
 	}
 


### PR DESCRIPTION
Since load_plugin_textdomain() needs relative path, the use of REVISR_PATH blocks translation loading

TODO : improve by using anything else than $this->domain
