### PR TITLE
hide strict standards errors

### DIFF
--- a/includes/class-revisr-list-table.php
+++ b/includes/class-revisr-list-table.php
@@ -14,7 +14,7 @@
 if ( ! defined( 'ABSPATH' ) ) exit;
 
 // Prevent PHP notices from breaking AJAX.
-error_reporting( ~E_NOTICE );
+error_reporting( ~E_NOTICE & ~E_STRICT );
 
 // Include WP_List_Table if it isn't already loaded.
 if ( ! class_exists( 'WP_List_Table' ) ) {


### PR DESCRIPTION
Using Revisr 1.9.1 on WordPress 4.1.1 with PHP 5.4.34, WordPress admin screens are throwing a bunch of Strict Standards PHP errors on WordPress core files when logged in, such as:

Strict Standards: call_user_func_array() expects parameter 1 to be a valid callback, non-static method wp_media_tags_plugin::media_tags_init() should not be called statically in /local/path/wp-includes/plugin.php on line 496

I think this error_reporting is resetting the E_STRICT flag for all calls, not just AJAX ones, so we should go ahead and stop it from firing. (You may decide this is too much of a brute force fix and instead sniff for whether the request is truly ajax or not)