### PR TITLE
Quote filepath for DB backup

### DIFF
--- a/includes/class-revisr-db.php
+++ b/includes/class-revisr-db.php
@@ -264,7 +264,7 @@ class Revisr_DB {
 	 */
 	private function backup_table( $table ) {
 		$conn = $this->build_conn( $table );
-		exec( "{$this->path}mysqldump $conn > {$this->backup_dir}revisr_$table.sql --skip-comments" );
+		exec( "{$this->path}mysqldump $conn > '{$this->backup_dir}revisr_$table.sql' --skip-comments" );
 		$this->add_table( $table );
 		return $this->verify_backup( $table );
 	}


### PR DESCRIPTION
Howdy! File paths with spaces in them (e.g., local development on Macs/Windows machines, if parent folders have spaces) bork when making database backups. Revisr returns "Error backing up the database," but it's because the mysqldump command is getting tripped up by the spaces. 

Quoting the filepath fixes that. (I haven't scrubbed to see if there are other places that might benefit from the quoting also.)