### PR TITLE
Add AMPPS path to MySQL info

### DIFF
--- a/includes/class-revisr-settings-fields.php
+++ b/includes/class-revisr-settings-fields.php
@@ -477,6 +477,7 @@ class Revisr_Settings_Fields {
 			esc_attr( $mysql_path ),
 			__( 'Leave blank if the full path to MySQL has already been set on the server. Some possible settings include:
 			<br><br>For MAMP: /Applications/MAMP/Library/bin/<br>
+			For AMPPS: /Applications/AMPPS/mysql/bin/<br>
 			For WAMP: C:\wamp\bin\mysql\mysql5.6.12\bin\ ', 'revisr' )
 		);
 	}


### PR DESCRIPTION
With a lot of devs dropping MAMP for AMPPS would be nice to help them find the Path to MySQL quicker. It took me half a hour to find out where it was located.