### PR TITLE
allow REVISR_BACKUP_DIR constant

### DIFF
--- a/classes/class-revisr-db.php
+++ b/classes/class-revisr-db.php
@@ -39,9 +39,14 @@ class Revisr_DB {
 		global $wpdb;
 		$this->wpdb = $wpdb;
 
-		$upload_dir = wp_upload_dir();
+		if ( defined( 'REVISR_BACKUP_DIR' ) && is_dir( REVISR_BACKUP_DIR ) ) {
+			$upload_dir_path = rtrim( REVISR_BACKUP_DIR, DIRECTORY_SEPARATOR );
+		} else {
+			$upload_dir = wp_upload_dir();
+			$upload_dir_path = $upload_dir['basedir'];
+		}
 
-		$this->backup_dir = $upload_dir['basedir'] . '/revisr-backups/';
+		$this->backup_dir = $upload_dir_path . '/revisr-backups/';
 
 		// Set up the "revisr_backups" directory if necessary.
 		$this->setup_env();

--- a/classes/class-revisr-db.php
+++ b/classes/class-revisr-db.php
@@ -39,8 +39,8 @@ class Revisr_DB {
 		global $wpdb;
 		$this->wpdb = $wpdb;
 
-		if ( defined( 'REVISR_BACKUP_DIR' ) && is_dir( REVISR_BACKUP_DIR ) ) {
-			$upload_dir_path = rtrim( REVISR_BACKUP_DIR, DIRECTORY_SEPARATOR );
+		if ( defined( 'REVISR_BACKUP_DIR' ) && is_dir( ABSPATH . REVISR_BACKUP_DIR ) ) {
+			$upload_dir_path = rtrim( ABSPATH . REVISR_BACKUP_DIR, DIRECTORY_SEPARATOR );
 		} else {
 			$upload_dir = wp_upload_dir();
 			$upload_dir_path = $upload_dir['basedir'];


### PR DESCRIPTION
Allow Revisr's .sql files to be stored in a directory other than the default WordPress uploads directory.
