### PR TITLE
Prevent trailing slash inconsistencies

### DIFF
--- a/classes/class-revisr-db-import.php
+++ b/classes/class-revisr-db-import.php
@@ -46,6 +46,8 @@ class Revisr_DB_Import extends Revisr_DB {
 
 		// Run a search replace if necessary.
 		if ( $replace_url !== '' && $replace_url !== false ) {
+			// Remove trailing slash if present.
+			$replace_url = rtrim($replace_url, '/');
 			$this->revisr_srdb( $table, $replace_url, $live_url );
 		}
 
@@ -87,6 +89,8 @@ class Revisr_DB_Import extends Revisr_DB {
 		fclose( $fh );
 
 		if ( '' !== $replace_url ) {
+			// Remove trailing slash if present.
+			$replace_url = rtrim($replace_url, '/');
 			$this->revisr_srdb( $table, $replace_url, $live_url );
 		}
 


### PR DESCRIPTION
Removes trailing slash, if present, from $replace_url so that it is consistent with the format of $live_url prior to performing search replace.