### PR TITLE
Mail subject charset

### DIFF
--- a/classes/class-revisr-admin.php
+++ b/classes/class-revisr-admin.php
@@ -157,7 +157,7 @@ class Revisr_Admin {
 			$email 		= $options['email'];
 			$message	.= '<br><br>';
 			$message	.= sprintf( __( '<a href="%s">Click here</a> for more details.', 'revisr' ), $url );
-			$headers 	= "Content-Type: text/html; charset=ISO-8859-1\r\n";
+			$headers 	= "Content-Type: text/html; charset=UTF-8\r\n";
 			wp_mail( $email, $subject, $message, $headers );
 		}
 	}


### PR DESCRIPTION
This solves expandedfronts/revisr#110 in my setup.
I am not shure it works in all settings.
I use gmail web client and see the following headers through _Show original_

    Subject: ...Gústa... - New Commit
    Content-Type: text/html; charset=UTF-8

instead of 

    Subject: ...GÃºsta... - New Commit
    Content-Type: text/html; charset=ISO-8859-1

maybe a universal solution requires a _subject_ formated like this

    =?UTF-8?B?R8O6c3Rh?=
